### PR TITLE
Added PNG/SVG image support

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -51,6 +51,7 @@
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.23.12",
     "gsap": "^3.13.0",
+    "html-to-image": "^1.11.13",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.544.0",
     "motion": "^12.23.12",


### PR DESCRIPTION
This update adds the ability for users to export their workflow canvas as PNG or SVG images directly from the Workflow Composer page.
It helps users save, share, and document their created workflows easily.

Key changes: Key Changes
Implemented exportImage() function using the html-to-image library.
Added Export PNG and Export SVG buttons to the Workflow Composer header.
Added support for large workflows using scrollWidth and scrollHeight.
Set white background and scaling to ensure clean exports.
Added loading state to show Exporting... while generating images. 

